### PR TITLE
use `lodash.*` modules instead of monolithic `lodash`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
   "dependencies": {
     "canonical": "^1.1.3",
     "immutable": "^3.7.4",
-    "lodash": "^3.10.1"
+    "lodash.every": "^3.2.3",
+    "lodash.foreach": "^3.0.3",
+    "lodash.isfunction": "^3.0.6",
+    "lodash.isplainobject": "^3.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import every from 'lodash.every';
+import isPlainObject from 'lodash.isplainobject';
+import isFunction from 'lodash.isfunction';
+import forEach from 'lodash.foreach';
 
 import Immutable from 'immutable';
 import {
@@ -15,7 +18,7 @@ let isActionMap,
  * @return {Boolean} If every object property value is a plain object.
  */
 isDomainMap = (map) => {
-    return _.every(map, _.isPlainObject);
+    return every(map, isPlainObject);
 };
 
 /**
@@ -23,7 +26,7 @@ isDomainMap = (map) => {
  * @return {Boolean} If every object property value is a function.
  */
 isActionMap = (map) => {
-    return _.every(map, _.isFunction);
+    return every(map, isFunction);
 };
 
 /**
@@ -42,10 +45,9 @@ iterator = (domain, action, collection, tapper) => {
     }
 
     newDomain = domain;
-
     // console.log(`domain`, domain, `action`, action, `definition`, collection);
 
-    _.forEach(collection, (value, domainName) => {
+    forEach(collection, (value, domainName) => {
         // console.log(`value`, value, `domain`, domainName, `isActionMap`, isActionMap(value), `isDomainMap`, isDomainMap(value));
 
         if (isActionMap(value)) {


### PR DESCRIPTION
reduces the browser bundle size, plus allows for de-deduplication of common lodash dependencies across modules.