### PR TITLE
Remove dependencies on lodash and pluralize

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "immutable": "^3.7.6",
-    "lodash": "^4.0.1",
-    "pluralize": "^1.2.1"
+    "immutable": "^3.7.6"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,10 +1,11 @@
-import _ from 'lodash';
 import {
     getUnexpectedInvocationParameterMessage,
     validateNextState
 } from './utilities';
 
 export default (reducers: Object) => {
+    let reducerKeys = Object.keys(reducers);
+
     return (inputState, action) => {
         /* eslint-disable no-process-env */
         if (process.env.NODE_ENV !== 'production') {
@@ -22,9 +23,12 @@ export default (reducers: Object) => {
 
         return inputState
             .withMutations((temporaryState) => {
-                _.forEach(reducers, (reducer, reducerName) => {
-                    let currentDomainState,
+                reducerKeys.forEach((reducerName) => {
+                    let reducer,
+                        currentDomainState,
                         nextDomainState;
+
+                    reducer = reducers[reducerName];
 
                     currentDomainState = temporaryState.get(reducerName);
 

--- a/src/utilities/getUnexpectedInvocationParameterMessage.js
+++ b/src/utilities/getUnexpectedInvocationParameterMessage.js
@@ -1,6 +1,4 @@
-import _ from 'lodash';
 import Immutable from 'immutable';
-import pluralize from 'pluralize';
 import getStateName from './getStateName';
 
 export default (state: Object, reducers: Object, action: Object) => {
@@ -8,9 +6,9 @@ export default (state: Object, reducers: Object, action: Object) => {
         stateName,
         unexpectedStatePropertyNames;
 
-    reducerNames = _.keys(reducers);
+    reducerNames = Object.keys(reducers);
 
-    if (_.isEmpty(reducerNames)) {
+    if (!reducerNames.length) {
         return 'Store does not have a valid reducer. Make sure the argument passed to combineReducers is an object whose values are reducers.';
     }
 
@@ -20,12 +18,12 @@ export default (state: Object, reducers: Object, action: Object) => {
         return 'The ' + stateName + ' is of unexpected type. Expected argument to be an instance of Immutable.Iterable with the following properties: "' + reducerNames.join('", "') + '".';
     }
 
-    unexpectedStatePropertyNames = _.filter(state.keySeq().toArray(), (name) => {
+    unexpectedStatePropertyNames = state.keySeq().toArray().filter((name) => {
         return !reducers.hasOwnProperty(name);
     });
 
-    if (!_.isEmpty(unexpectedStatePropertyNames)) {
-        return 'Unexpected ' + pluralize('property', unexpectedStatePropertyNames.length) + ' "' + unexpectedStatePropertyNames.join('", "') + '" found in ' + stateName + '. Expected to find one of the known reducer property names instead: "' + reducerNames.join('", "') + '". Unexpected properties will be ignored.';
+    if (unexpectedStatePropertyNames.length > 0) {
+        return 'Unexpected ' + (unexpectedStatePropertyNames.length === 1 ? 'property' : 'properties') + ' "' + unexpectedStatePropertyNames.join('", "') + '" found in ' + stateName + '. Expected to find one of the known reducer property names instead: "' + reducerNames.join('", "') + '". Unexpected properties will be ignored.';
     }
 
     return null;

--- a/src/utilities/validateNextState.js
+++ b/src/utilities/validateNextState.js
@@ -1,7 +1,5 @@
-import _ from 'lodash';
-
 export default (nextState: Object, reducerName: string, action: Object): null => {
-    if (_.isUndefined(nextState)) {
+    if (typeof nextState === 'undefined') {
         throw new Error('Reducer "' + reducerName + '" returned undefined when handling "' + action.type + '" action. To ignore an action, you must explicitly return the previous state.');
     }
 


### PR DESCRIPTION
I only now realized that these are dependencies. In general we try to pick projects with as least dependencies as possible for our Ecosystem packages. I don't think Lodash dependency is justified here, as it increases bundle size for a few utility functions.

Unfortunately I couldn't figure out how to fix the linter to not complain about usage of built-in functions. I understand if you don't want to take this, but unfortunately we can't officially recommend a package that brings in the whole Lodash for the sake of `combineReducers()`.