### PR TITLE
Make immutable a peer and dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "immutable": "^3.7.6",
     "lodash": "^4.0.1",
     "pluralize": "^1.2.1"
   },
@@ -26,7 +25,11 @@
     "benchmark": "^2.1.0",
     "chai": "^3.5.0",
     "create-index": "0.0.2",
+    "immutable": "^3.7.6",
     "pragmatist": "^3.0.3"
+  },
+  "peerDependencies": {
+    "immutable": "^3.7.6"
   },
   "scripts": {
     "create-index": "create-index ./src/utilities",


### PR DESCRIPTION
I believe it should be a peer to avoid dragging in two versions of Immutable at the same time. With npm@3, peers are not installed by default which ensures this wouldn't happen. Since this library is more like a plugin for Immutable and Redux, I think this makes more sense.