### PR TITLE
Support nested reducers

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,14 @@
     "url": "http://gajus.com"
   },
   "license": "BSD-3-Clause",
-  "dependencies": {},
+  "dependencies": {
+    "immutable": "^3.7.6"
+  },
   "devDependencies": {
     "benchmark": "^2.1.0",
     "chai": "^3.5.0",
     "create-index": "0.1.2",
-    "immutable": "^3.7.6",
     "pragmatist": "^3.0.13"
-  },
-  "peerDependencies": {
-    "immutable": "^3.7.6"
   },
   "scripts": {
     "create-index": "create-index --update-index ./src/utilities",

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -5,12 +5,18 @@ import {
     validateNextState
 } from './utilities';
 
+import Immutable from 'immutable';
+
 export default (reducers: Object) => {
     let reducerKeys;
 
     reducerKeys = Object.keys(reducers);
 
     return (inputState, action) => {
+        if (inputState === undefined) {
+          inputState = Immutable.Map();
+        }
+
         /* eslint-disable no-process-env */
         if (process.env.NODE_ENV !== 'production') {
         /* eslint-enable no-process-env */

--- a/tests/combineReducers.js
+++ b/tests/combineReducers.js
@@ -49,4 +49,33 @@ describe('combineReducers()', () => {
             expect(rootReducer(initialState, {type: 'ADD'}).getIn(['foo', 'count'])).to.equal(1);
         });
     });
+    context('root reducer is created from nested combineReducers', () => {
+        it('returns initial state from default values', () => {
+            const initialState = Immutable.fromJS({
+                outer: {
+                    inner1: {
+                        a: true,
+                        b: false
+                    },
+                    inner2: {
+                        a: false,
+                        b: true
+                    }
+                }
+            });
+
+            const rootReducer = combineReducers({
+                outer: combineReducers({
+                    inner1: (state = Immutable.fromJS({a: true, b: false})) => {
+                        return state;
+                    },
+                    inner2: (state = Immutable.fromJS({a: false, b: true})) => {
+                        return state;
+                    }
+                })
+            });
+
+            expect(rootReducer()).to.eql(initialState);
+        });
+    });
 });


### PR DESCRIPTION
As discussed in #22, this PR adds support for nested `combineReducers` calls by defaulting to an empty immutable map if the `inputState` is undefined.

This adds a test for this behavior as well.