### PR TITLE
Fix potential infinite recursion in react-router-redux example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ const initialState = Immutable.fromJS({
 
 export default (state = initialState, action) => {
     if (action.type === LOCATION_CHANGE) {
-        return state.merge({
-            locationBeforeTransitions: action.payload
-        });
+        return state.set("locationBeforeTransitions", action.payload);
     }
 
     return state;
@@ -74,7 +72,7 @@ import {
 
 const history = syncHistoryWithStore(browserHistory, store, {
     selectLocationState (state) {
-        return state.get('routing').toJS();
+        return state.get('routing').toObject();
     } 
 });
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const initialState = Immutable.fromJS({
 
 export default (state = initialState, action) => {
     if (action.type === LOCATION_CHANGE) {
-        return state.set("locationBeforeTransitions", action.payload);
+        return state.set('locationBeforeTransitions', action.payload);
     }
 
     return state;


### PR DESCRIPTION
I started getting a `Maximum call stack size exceeded` error after adding some code to dispatch actions via `onEnter` hooks in react-router. I had used the code in the README to link up redux-immutable and react-router-redux.

It turns out that react-router-redux performs a strict equality check on the location object. The example in this repository merges the data directly into the store, which causes said object to be converted into an Immutable data structure. The strict equality check will fail once it is converted back to JS, making react-router-redux think the location has changed. Such change will lead to the `onEnter` hook being run again, and so on.

The proposed change modifies the code to explicitly set the "locationBeforeTransitions" key to the action's payload, which will preserve it as a plain object.

It also changes `toJS()` to `toObject()` in `selectLocationState()`. This provides no real practical difference, but has the advantage of being less ambiguous about what data will be returned, because anything beyond the top-level map is returned verbatim.
