### PR TITLE
Update for RequireJS compatibility

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -2,7 +2,7 @@ import Immutable from 'immutable';
 import {
     getUnexpectedInvocationParameterMessage,
     validateNextState
-} from './utilities';
+} from './utilities/index';
 
 export default (reducers: Object): Function => {
   const reducerKeys = Object.keys(reducers);

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,5 +1,5 @@
 'create index';
 
-export getStateName from './getStateName.js';
-export getUnexpectedInvocationParameterMessage from './getUnexpectedInvocationParameterMessage.js';
-export validateNextState from './validateNextState.js';
+export getStateName from './getStateName';
+export getUnexpectedInvocationParameterMessage from './getUnexpectedInvocationParameterMessage';
+export validateNextState from './validateNextState';


### PR DESCRIPTION
current release 3.0.10 is not loadable by RequireJS

from http://requirejs.org/docs/api.html#jsfiles

> RequireJS also assumes by default that all dependencies are scripts, so it does not expect to see a trailing ".js" suffix on module IDs. RequireJS will automatically add it when translating the module ID to a path

created based on discussion here https://github.com/aurelia/cli/issues/428