### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+export interface Action {
+  type: any;
+}
+
+export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
+
+export interface ReducersMapObject {
+  [key: string]: Reducer<any>;
+}
+
+export declare function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,8 @@
+/**
+ * Typings from the official redux repository.
+ * Source: https://github.com/reactjs/redux/blob/master/index.d.ts
+ */
+
 export interface Action {
   type: any;
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "http://gajus.com"
   },
   "license": "BSD-3-Clause",
+  "typings": "./index.d.ts",
   "dependencies": {
     "flow-runtime": "0.0.6",
     "immutable": "^3.8.1"


### PR DESCRIPTION
Hi @gajus can I interest you in some typings for TypeScript? 🙂

It would be nice for the TypeScript users, if the definition file would be included directly in the repository. Although somebody already published typings to `@types/redux-immutable` the typings are wrong/do not catch every error.

Having typings directly in the module is good for DX and keep the typings in sync.