### PR TITLE
Make flow-runtime a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "flow-runtime": "0.0.6",
     "immutable": "^3.8.1"
   },
   "devDependencies": {
@@ -34,6 +33,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.13.1",
     "eslint-config-canonical": "^6.0.0",
+    "flow-runtime": "0.0.6",
     "husky": "^0.12.0",
     "mocha": "^3.2.0",
     "semantic-release": "^6.3.2"


### PR DESCRIPTION
since it is not needed for running the library