### PR TITLE
Immutable v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const rootReducer = combineReducers({foo: fooReducer}, StateRecord);
 // state now must always have 'foo' property with its default value returned from fooReducer(undefined, action)
 ```
 
-In general, `getDefaultState` function must return an instance of `Immutable.Iterable` that implements `get`, `set` and `withMutations` methods. Such iterables are `List`, `Map`, `OrderedMap` and `Record`.
+In general, `getDefaultState` function must return an instance of `Immutable.Record` or `Immutable.Collection` that implements `get`, `set` and `withMutations` methods. Such collections are `List`, `Map` and `OrderedMap`.
 
 ### Using with `react-router-redux`
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 `redux-immutable` is used to create an equivalent function of Redux [`combineReducers`](http://redux.js.org/docs/api/combineReducers.html) that works with [Immutable.js](https://facebook.github.io/immutable-js/) state.
 
-When Redux [`createStore`](https://github.com/reactjs/redux/blob/master/docs/api/createStore.md) `reducer` is created using `redux-immutable` then `initialState` must be an instance of [`Immutable.Iterable`](https://facebook.github.io/immutable-js/docs/#/Iterable).
+When Redux [`createStore`](https://github.com/reactjs/redux/blob/master/docs/api/createStore.md) `reducer` is created using `redux-immutable` then `initialState` must be an instance of [`Immutable.Collection`](https://facebook.github.io/immutable-js/docs/#/Collection).
 
 ## Problem
 
-When [`createStore`](https://github.com/reactjs/redux/blob/v3.0.6/docs/api/createStore.md) is invoked with `initialState` that is an instance of `Immutable.Iterable` further invocation of reducer will [produce an error](https://github.com/reactjs/redux/blob/v3.0.6/src/combineReducers.js#L31-L38):
+When [`createStore`](https://github.com/reactjs/redux/blob/v3.0.6/docs/api/createStore.md) is invoked with `initialState` that is an instance of `Immutable.Collection` further invocation of reducer will [produce an error](https://github.com/reactjs/redux/blob/v3.0.6/src/combineReducers.js#L31-L38):
 
 > The initialState argument passed to createStore has unexpected type of "Object".
 > Expected argument to be an object with the following keys: "data"
@@ -21,7 +21,7 @@ This is because Redux `combineReducers` [treats `state` object as a plain JavaSc
 
 ## Usage
 
-Create a store with `initialState` set to an instance of [`Immutable.Iterable`](https://facebook.github.io/immutable-js/docs/#/Iterable):
+Create a store with `initialState` set to an instance of [`Immutable.Collection`](https://facebook.github.io/immutable-js/docs/#/Collection):
 
 ```js
 import {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "url": "http://gajus.com"
   },
   "license": "BSD-3-Clause",
-  "dependencies": {
-    "immutable": "^3.8.1"
-  },
+	"peerDependencies": {
+		"immutable": "^3.8.1 || ^4.0.0-rc.1"
+	},
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
@@ -35,6 +35,7 @@
     "eslint-config-canonical": "^6.0.0",
     "flow-runtime": "0.0.6",
     "husky": "^0.12.0",
+		"immutable": "^3.8.1 || ^4.0.0-rc.1",
     "mocha": "^3.2.0",
     "semantic-release": "^6.3.2"
   },

--- a/src/utilities/getUnexpectedInvocationParameterMessage.js
+++ b/src/utilities/getUnexpectedInvocationParameterMessage.js
@@ -11,7 +11,7 @@ export default (state: Object, reducers: Object, action: Object) => {
   const stateName = getStateName(action);
 
   if (Immutable.isImmutable ? !Immutable.isImmutable(state) : !Immutable.Iterable.isIterable(state)) {
-    return 'The ' + stateName + ' is of unexpected type. Expected argument to be an instance of Immutable.Iterable with the following properties: "' + reducerNames.join('", "') + '".';
+    return 'The ' + stateName + ' is of unexpected type. Expected argument to be an instance of Immutable.Collection or Immutable.Record with the following properties: "' + reducerNames.join('", "') + '".';
   }
 
   const unexpectedStatePropertyNames = state.toSeq().keySeq().toArray().filter((name) => {

--- a/src/utilities/getUnexpectedInvocationParameterMessage.js
+++ b/src/utilities/getUnexpectedInvocationParameterMessage.js
@@ -10,7 +10,7 @@ export default (state: Object, reducers: Object, action: Object) => {
 
   const stateName = getStateName(action);
 
-  if (!Immutable.Iterable.isIterable(state)) {
+  if (Immutable.isImmutable ? !Immutable.isImmutable(state) : !Immutable.Iterable.isIterable(state)) {
     return 'The ' + stateName + ' is of unexpected type. Expected argument to be an instance of Immutable.Iterable with the following properties: "' + reducerNames.join('", "') + '".';
   }
 

--- a/src/utilities/getUnexpectedInvocationParameterMessage.js
+++ b/src/utilities/getUnexpectedInvocationParameterMessage.js
@@ -14,7 +14,7 @@ export default (state: Object, reducers: Object, action: Object) => {
     return 'The ' + stateName + ' is of unexpected type. Expected argument to be an instance of Immutable.Iterable with the following properties: "' + reducerNames.join('", "') + '".';
   }
 
-  const unexpectedStatePropertyNames = state.keySeq().toArray().filter((name) => {
+  const unexpectedStatePropertyNames = state.toSeq().keySeq().toArray().filter((name) => {
     return !reducers.hasOwnProperty(name);
   });
 

--- a/tests/utilities/getUnexpectedInvocationParameterMessage.js
+++ b/tests/utilities/getUnexpectedInvocationParameterMessage.js
@@ -29,11 +29,11 @@ describe('utilities', () => {
         expect(expectedErrorMessage).to.equal('Store does not have a valid reducer. Make sure the argument passed to combineReducers is an object whose values are reducers.');
       });
     });
-    context('state is not an instance of Immutable.Iterable', () => {
+    context('state is not an instance of Immutable.Collection or Immutable.Record', () => {
       it('returns error', () => {
         const expectedErrorMessage = getUnexpectedInvocationParameterMessage({}, validReducers, validAction);
 
-        expect(expectedErrorMessage).to.equal('The initialState argument passed to createStore is of unexpected type. Expected argument to be an instance of Immutable.Iterable with the following properties: "foo".');
+        expect(expectedErrorMessage).to.equal('The initialState argument passed to createStore is of unexpected type. Expected argument to be an instance of Immutable.Collection or Immutable.Record with the following properties: "foo".');
       });
     });
     context('state defines properties that are not present in the reducer map', () => {


### PR DESCRIPTION
Closes #46 

Also I would like to propose separating `immutable` dependency into `peerDependencies` and `devDependencies`:

```json
"peerDependencies": {
  "immutable": "^3.8.1 || ^4.0.0-rc.1"
},
"devDependencies": {
  "immutable": "^3.8.1 || ^4.0.0-rc.1"
}
```

That way if a user's project at large uses `immutable@^4`, **redux-immutable** won't try to pull in `immutable@3.8.1` as a local dependency, but rather import from the project. Avoids bloating up bundle size.

Conditional `devDependencies` avoids npm warnings when switching between `immutable` versions in development. `3.8.1` is installed by default.