### PR TITLE
Pass the whole state to reducer as a third parameter

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -24,7 +24,7 @@ export default (reducers: Object, getDefaultState: ?Function = Immutable.Map): F
         reducerKeys.forEach((reducerName) => {
           const reducer = reducers[reducerName];
           const currentDomainState = temporaryState.get(reducerName);
-          const nextDomainState = reducer(currentDomainState, action);
+          const nextDomainState = reducer(currentDomainState, action, temporaryState);
 
           validateNextState(nextDomainState, reducerName, action);
 


### PR DESCRIPTION
I really think it can be pretty useful in some application to have access to the whole state in slice reducers. Taking into account state is immutable (especially here, in immutablejs context), I think there are no possible side effects.