### PR TITLE
Added documentation on using with react-router-redux v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const rootReducer = combineReducers({foo: fooReducer}, StateRecord);
 
 In general, `getDefaultState` function must return an instance of `Immutable.Record` or `Immutable.Collection` that implements `get`, `set` and `withMutations` methods. Such collections are `List`, `Map` and `OrderedMap`.
 
-### Using with `react-router-redux`
+### Using with `react-router-redux` v4 and under
 
 `react-router-redux` [`routeReducer`](https://github.com/reactjs/react-router-redux/tree/v4.0.2#routerreducer) does not work with Immutable.js. You need to use a custom reducer:
 
@@ -101,3 +101,28 @@ const history = syncHistoryWithStore(browserHistory, store, {
 ```
 
 The `'routing'` path depends on the `rootReducer` definition. This example assumes that `routeReducer` is made available under `routing` property of the `rootReducer`.
+
+### Using with `react-router-redux` v5
+To make [`react-router-redux` v5](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-redux) work with Immutable.js you only need to use a custom reducer:
+
+```js
+import {Map}             from 'immutable';
+import {LOCATION_CHANGE} from 'react-router-redux';
+
+const initialState = Map({
+                             location: null,
+                             action:   null
+                         });
+
+export function routerReducer(state = initialState, {type, payload = {}} = {}) {
+    if (type === LOCATION_CHANGE) {
+        const location = payload.location || payload;
+        const action   = payload.action;
+
+        return state.set('location', location)
+                    .set('action', action);
+    }
+
+    return state;
+}
+```

--- a/README.md
+++ b/README.md
@@ -106,23 +106,29 @@ The `'routing'` path depends on the `rootReducer` definition. This example assum
 To make [`react-router-redux` v5](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-redux) work with Immutable.js you only need to use a custom reducer:
 
 ```js
-import {Map}             from 'immutable';
-import {LOCATION_CHANGE} from 'react-router-redux';
+import {
+  Map
+} from 'immutable';
+import {
+  LOCATION_CHANGE
+} from 'react-router-redux';
 
 const initialState = Map({
-                             location: null,
-                             action:   null
-                         });
+  location: null,
+  action: null
+});
 
 export function routerReducer(state = initialState, {type, payload = {}} = {}) {
-    if (type === LOCATION_CHANGE) {
-        const location = payload.location || payload;
-        const action   = payload.action;
+  if (type === LOCATION_CHANGE) {
+    const location = payload.location || payload;
+    const action = payload.action;
 
-        return state.set('location', location)
-                    .set('action', action);
-    }
+    return state
+      .set('location', location)
+      .set('action', action);
+  }
 
-    return state;
+  return state;
 }
+
 ```


### PR DESCRIPTION
syncHistoryWithStore has been deprecated in v5. ConnectedRouter will make sure to keep the store in sync with history. It does this by listening to history, and dispatching LOCATION_CHANGE actions.

In version 5 the store is being accessed in two places only: routerReducer and createMatchSelector
To get things working the only thing one has to update is the routerReducer.

Patching createMatchSelector is optional.