### PR TITLE
Bump version in package.json to match with npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "immutable",
     "redux"
   ],
-  "version": "3.0.10",
+  "version": "4.0.0",
   "author": {
     "name": "Gajus Kuizinas",
     "email": "gajus@anuary.com",


### PR DESCRIPTION
The version of `redux-immutable` in npm in `4.0.0` but it's `3.0.10` in `package.json`. That could lead to confusion (at least I was confused by it).