### PR TITLE
Improve tree-shaking

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,14 +1,14 @@
-import Immutable from 'immutable';
+import { Map as ImmutableMap } from 'immutable';
 import {
   getUnexpectedInvocationParameterMessage,
   validateNextState
 } from './utilities';
 
-export default (reducers: Object, getDefaultState: ?Function = Immutable.Map): Function => {
+export default (reducers: Object, getDefaultState: ?Function = ImmutableMap): Function => {
   const reducerKeys = Object.keys(reducers);
 
   // eslint-disable-next-line space-infix-ops
-  return (inputState: ?Function = getDefaultState(), action: Object): Immutable.Map => {
+  return (inputState: ?Function = getDefaultState(), action: Object): ImmutableMap => {
     // eslint-disable-next-line no-process-env
     if (process.env.NODE_ENV !== 'production') {
       const warningMessage = getUnexpectedInvocationParameterMessage(inputState, reducers, action);

--- a/src/utilities/getUnexpectedInvocationParameterMessage.js
+++ b/src/utilities/getUnexpectedInvocationParameterMessage.js
@@ -1,5 +1,5 @@
 
-import Immutable from 'immutable';
+import { isCollection } from 'immutable';
 import getStateName from './getStateName';
 
 export default (state: Object, reducers: Object, action: Object) => {
@@ -11,7 +11,7 @@ export default (state: Object, reducers: Object, action: Object) => {
 
   const stateName = getStateName(action);
 
-  if (!Immutable.isCollection(state)) {
+  if (!isCollection(state)) {
     return 'The ' + stateName + ' is of unexpected type. Expected argument to be an instance of Immutable.Collection or Immutable.Record with the following properties: "' + reducerNames.join('", "') + '".';
   }
 

--- a/tests/utilities/validateNextState.js
+++ b/tests/utilities/validateNextState.js
@@ -3,7 +3,7 @@
 import {
   expect
 } from 'chai';
-import Immutable from 'immutable';
+import { Map as ImmutableMap } from 'immutable';
 import validateNextState from '../../src/utilities/validateNextState';
 
 describe('utilities', () => {
@@ -20,7 +20,7 @@ describe('utilities', () => {
     });
     context('state is defined', () => {
       it('returns undefined', () => {
-        const result = validateNextState(Immutable.Map(), 'reducer name', {
+        const result = validateNextState(ImmutableMap(), 'reducer name', {
           type: 'foo'
         });
 


### PR DESCRIPTION
Immutable 4 is working towards proper tree-shaking. Import only what we need, or the bundler will be forced to take the whole library.